### PR TITLE
fix: Enable publishing to Docker Hub

### DIFF
--- a/lib/scripts/docker-upload.sh
+++ b/lib/scripts/docker-upload.sh
@@ -5,7 +5,6 @@
 # registry using skopeo. It supports Google Cloud Registry authentication.
 #
 # Required environment variables:
-#   GOOGLE_ACCESS_TOKEN - Access token for registry authentication
 #   IMAGE_TARGET        - Full registry path (e.g., gcr.io/project/image:tag)
 #   IMAGE_DERIVATION    - Nix store path or flake reference to build
 #
@@ -27,7 +26,6 @@ validate_env_var() {
 }
 
 # Validate required environment variables
-validate_env_var "GOOGLE_ACCESS_TOKEN"
 validate_env_var "IMAGE_TARGET"
 validate_env_var "IMAGE_DERIVATION"
 
@@ -52,12 +50,14 @@ if [[ ! -f $OCI_ARCHIVE ]]; then
 fi
 
 echo "Docker image built successfully: $OCI_ARCHIVE"
-
+local skopeo_args=()
 # Prepare skopeo command with security options
-skopeo_args=(
-  "copy"
-  "--dest-registry-token=$GOOGLE_ACCESS_TOKEN"
-)
+if [[ -n ${GOOGLE_ACCESS_TOKEN:-} ]]; then
+  skopeo_args+=(
+    "copy"
+    "--dest-registry-token=$GOOGLE_ACCESS_TOKEN"
+  )
+fi
 
 # Add insecure policy flag only if explicitly requested
 if [[ ${SKOPEO_INSECURE_POLICY:-} == "1" ]]; then

--- a/lib/scripts/docker-upload.sh
+++ b/lib/scripts/docker-upload.sh
@@ -50,11 +50,10 @@ if [[ ! -f $OCI_ARCHIVE ]]; then
 fi
 
 echo "Docker image built successfully: $OCI_ARCHIVE"
-local skopeo_args=()
+skopeo_args=("copy")
 # Prepare skopeo command with security options
 if [[ -n ${GOOGLE_ACCESS_TOKEN:-} ]]; then
   skopeo_args+=(
-    "copy"
     "--dest-registry-token=$GOOGLE_ACCESS_TOKEN"
   )
 fi

--- a/lib/scripts/multi-arch-upload.sh
+++ b/lib/scripts/multi-arch-upload.sh
@@ -5,7 +5,6 @@
 # manifest and creates a manifest list that enables automatic platform selection.
 #
 # Required environment variables:
-#   GOOGLE_ACCESS_TOKEN - Access token for registry authentication
 #   IMAGE_TARGET        - Full registry path (e.g., gcr.io/project/image:tag)
 #   MANIFEST_DIR        - Path to the manifest directory containing images and metadata
 
@@ -24,7 +23,6 @@ validate_env_var() {
 }
 
 # Validate required environment variables
-validate_env_var "GOOGLE_ACCESS_TOKEN"
 validate_env_var "IMAGE_TARGET"
 validate_env_var "MANIFEST_DIR"
 
@@ -59,11 +57,13 @@ for platform in $PLATFORMS; do
 done
 echo ""
 
+skopeo_base_args=("--policy=$POLICY_JSON")
 # Prepare skopeo base args
-skopeo_base_args=(
-  "--dest-registry-token=$GOOGLE_ACCESS_TOKEN"
-  "--policy=$POLICY_JSON"
-)
+if [[ -n ${GOOGLE_ACCESS_TOKEN:-} ]]; then
+  skopeo_base_args+=(
+    "--dest-registry-token=$GOOGLE_ACCESS_TOKEN"
+  )
+fi
 
 # Array to store pushed image references for manifest creation
 PUSHED_REFS=()
@@ -113,13 +113,6 @@ echo ""
 
 # Extract registry from IMAGE_TARGET (e.g., gcr.io from gcr.io/project/image:tag)
 REGISTRY=$(echo "$IMAGE_TARGET" | cut -d'/' -f1)
-
-# Authenticate with crane using the Google access token
-echo "Authenticating with registry: $REGISTRY"
-if ! echo "$GOOGLE_ACCESS_TOKEN" | crane auth login "$REGISTRY" --username=oauth2accesstoken --password-stdin; then
-  echo "ERROR: Failed to authenticate with registry" >&2
-  exit 4
-fi
 
 echo "Creating multi-architecture manifest..."
 


### PR DESCRIPTION
The current config forces to use a Google Artifact token. With this change the CI can login to Docker hub and read credentials from ~/.docker/config.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made registry authentication token optional for image uploads; workflows now proceed without a token and will use it only if provided.
  * Removed automatic registry authentication step; conditional token handling is applied where needed.
  * Minor formatting and argument-construction adjustments; existing upload and policy behaviors remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->