### PR TITLE
feat: add code coverage support via crane's cargoLlvmCov

### DIFF
--- a/examples/rust-app/flake.nix
+++ b/examples/rust-app/flake.nix
@@ -169,6 +169,18 @@
               runClippy = true;
             };
 
+            # Code coverage (outputs LCOV report)
+            coverage = builders.localCoverage.callPackage lib.mkRustPackage {
+              src = sources.test;
+              depsSrc = sources.deps;
+              cargoToml = ./Cargo.toml;
+              inherit rev;
+              runCoverage = true;
+              # Override defaults if needed:
+              # cargoLlvmCovExtraArgs = "--html --output-dir $out";
+              # cargoLlvmCovCommand = "test";
+            };
+
             # Formatting check
             formatting = config.treefmt.build.check self;
           };

--- a/examples/rust-app/flake.nix
+++ b/examples/rust-app/flake.nix
@@ -147,6 +147,7 @@
           # Development shell
           devShells.default = lib.mkDevShell {
             shellName = "Rust App Example";
+            withLlvmTools = true;
             extraPackages = with pkgs; [
               # Additional development tools
               cargo-edit

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -174,6 +174,7 @@ rec {
       treefmtPrograms ? [ ],
       includePostgres ? false,
       postgresPackage ? null,
+      withLlvmTools ? false,
     }:
     import ./shells.nix {
       inherit
@@ -188,7 +189,9 @@ rec {
         treefmtPrograms
         includePostgres
         postgresPackage
+        withLlvmTools
         ;
+      pkgsUnstable = pkgsUnstable;
     };
 
   # Code Formatting

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,6 +80,7 @@ rec {
       isStatic ? false,
       useRustNightly ? false,
       rustToolchainFile ? null,
+      withLlvmTools ? false,
     }:
     import ./rust-builder.nix {
       inherit
@@ -92,6 +93,7 @@ rec {
         isStatic
         useRustNightly
         rustToolchainFile
+        withLlvmTools
         ;
     };
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -61,6 +61,7 @@ rec {
       buildersLib = import ./rust-builders.nix {
         inherit
           nixpkgs
+          nixpkgs-unstable
           rust-overlay
           crane
           localSystem
@@ -85,6 +86,7 @@ rec {
     import ./rust-builder.nix {
       inherit
         nixpkgs
+        nixpkgs-unstable
         rust-overlay
         crane
         localSystem

--- a/lib/rust-builder.nix
+++ b/lib/rust-builder.nix
@@ -57,7 +57,7 @@ let
   cargoTarget =
     if hostPlatform.config == "arm64-apple-darwin" then "aarch64-apple-darwin" else hostPlatform.config;
 
-  llvmToolsExtensions = if withLlvmTools then [ "llvm-tools" ] else [ ];
+  llvmToolsExtensions = if withLlvmTools then [ "llvm-tools-preview" ] else [ ];
 
   rustToolchainFun =
     if useRustNightly then

--- a/lib/rust-builder.nix
+++ b/lib/rust-builder.nix
@@ -13,6 +13,7 @@
   isStatic ? false, # Whether to create statically linked binaries
   localSystem, # Host system where compilation occurs
   nixpkgs, # Nixpkgs package set
+  nixpkgs-unstable ? nixpkgs, # Unstable nixpkgs (used for cargo-llvm-cov)
   rust-overlay, # Rust toolchain overlay
   useRustNightly ? false, # Whether to use nightly Rust toolchain
   rustToolchainFile ? null, # Optional path to rust-toolchain.toml
@@ -80,7 +81,23 @@ let
         extensions = llvmToolsExtensions;
       };
 
-  craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchainFun;
+  craneLibBase = (crane.mkLib pkgs).overrideToolchain rustToolchainFun;
+
+  # When llvm-tools are enabled (for coverage), override cargo-llvm-cov to use
+  # the version from nixpkgs-unstable, as the release channel may have it
+  # marked as broken or outdated.
+  pkgsUnstableLocal = import nixpkgs-unstable {
+    localSystem = args.localSystem;
+  };
+  craneLib =
+    if withLlvmTools then
+      craneLibBase.overrideScope (
+        _final: _prev: {
+          cargo-llvm-cov = pkgsUnstableLocal.cargo-llvm-cov;
+        }
+      )
+    else
+      craneLibBase;
 
   # mold is only supported on Linux builds, so falling back to lld for Darwin
   linker = if buildPlatform.isDarwin then "lld" else "mold";

--- a/lib/rust-builder.nix
+++ b/lib/rust-builder.nix
@@ -16,6 +16,7 @@
   rust-overlay, # Rust toolchain overlay
   useRustNightly ? false, # Whether to use nightly Rust toolchain
   rustToolchainFile ? null, # Optional path to rust-toolchain.toml
+  withLlvmTools ? false, # Whether to include llvm-tools for code coverage
 }@args:
 let
   crossSystem0 = crossSystem;
@@ -55,18 +56,28 @@ let
   cargoTarget =
     if hostPlatform.config == "arm64-apple-darwin" then "aarch64-apple-darwin" else hostPlatform.config;
 
+  llvmToolsExtensions = if withLlvmTools then [ "llvm-tools" ] else [ ];
+
   rustToolchainFun =
     if useRustNightly then
-      p: p.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default)
+      p:
+      p.rust-bin.selectLatestNightlyWith (
+        toolchain:
+        toolchain.default.override {
+          extensions = llvmToolsExtensions;
+        }
+      )
     else if rustToolchainFile != null then
       p:
       (p.rust-bin.fromRustupToolchainFile rustToolchainFile).override {
         targets = [ cargoTarget ];
+        extensions = llvmToolsExtensions;
       }
     else
       p:
       p.rust-bin.stable.latest.default.override {
         targets = [ cargoTarget ];
+        extensions = llvmToolsExtensions;
       };
 
   craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchainFun;
@@ -105,7 +116,10 @@ let
   targetOpenssl = if isStatic then pkgs.pkgsStatic.openssl else pkgs.openssl;
   buildHostOpenssl = pkgsLocal.openssl;
   buildHostTarget =
-    if buildPlatform.config == "arm64-apple-darwin" then "aarch64-apple-darwin" else buildPlatform.config;
+    if buildPlatform.config == "arm64-apple-darwin" then
+      "aarch64-apple-darwin"
+    else
+      buildPlatform.config;
 
   buildEnvOpenssl =
     if isCross then

--- a/lib/rust-builders.nix
+++ b/lib/rust-builders.nix
@@ -21,9 +21,11 @@ rec {
   #
   # Arguments:
   #   useRustNightly: Whether to use nightly Rust toolchain (default: false)
+  #   withLlvmTools: Whether to include llvm-tools for code coverage (default: false)
   mkLocalBuilder =
     {
       useRustNightly ? false,
+      withLlvmTools ? false,
     }:
     import ./rust-builder.nix {
       inherit
@@ -32,6 +34,7 @@ rec {
         crane
         localSystem
         useRustNightly
+        withLlvmTools
         rustToolchainFile
         ;
     };
@@ -111,6 +114,12 @@ rec {
       isCross = true;
     };
 
+  # Create a Rust builder for the local platform with llvm-tools
+  # This builder includes LLVM instrumentation tools required for code coverage
+  #
+  # Arguments: none
+  mkCoverageBuilder = { }: mkLocalBuilder { withLlvmTools = true; };
+
   # Helper function to create all platform builders at once
   # Returns an attribute set with all available builders
   #
@@ -123,6 +132,7 @@ rec {
   #   {
   #     local: Local platform builder
   #     localNightly: Local platform builder with nightly toolchain
+  #     localCoverage: Local platform builder with llvm-tools for code coverage
   #     x86_64-linux: x86_64 Linux static builder
   #     aarch64-linux: aarch64 Linux static builder
   #     x86_64-darwin: x86_64 macOS builder
@@ -133,6 +143,7 @@ rec {
     {
       local = mkLocalBuilder { };
       localNightly = mkLocalBuilder { useRustNightly = true; };
+      localCoverage = mkCoverageBuilder { };
       x86_64-linux = mkX86_64LinuxBuilder { };
       aarch64-linux = mkAarch64LinuxBuilder { };
       x86_64-darwin = mkX86_64DarwinBuilder { };

--- a/lib/rust-builders.nix
+++ b/lib/rust-builders.nix
@@ -9,6 +9,7 @@
 
 {
   nixpkgs,
+  nixpkgs-unstable ? nixpkgs,
   rust-overlay,
   crane,
   localSystem,
@@ -30,6 +31,7 @@ rec {
     import ./rust-builder.nix {
       inherit
         nixpkgs
+        nixpkgs-unstable
         rust-overlay
         crane
         localSystem

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -146,7 +146,13 @@ let
     ++ extraNativeBuildInputs;
     buildInputs = buildInputs ++ stdenv.extraBuildInputs ++ darwinBuildInputs ++ extraBuildInputs;
 
-    cargoExtraArgs = if prependPackageName then "-p ${pname} ${cargoExtraArgs}" else cargoExtraArgs;
+    cargoExtraArgs =
+      if runCoverage then
+        "--workspace ${cargoExtraArgs}"
+      else if prependPackageName then
+        "-p ${pname} ${cargoExtraArgs}"
+      else
+        cargoExtraArgs;
     strictDeps = true;
     # disable running tests automatically for now
     doCheck = false;

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -66,9 +66,9 @@ let
   crateInfo = craneLib.crateNameFromCargoToml { inherit cargoToml; };
   pname = crateInfo.pname;
   actualCargoProfile =
-    if runTests then
+    if runCoverage then
       "test"
-    else if runCoverage then
+    else if runTests then
       "test"
     else if runClippy then
       "dev"
@@ -161,18 +161,18 @@ let
   };
 
   sharedArgs =
-    if runTests then
+    if runCoverage then
+      sharedArgsBase
+      // {
+        inherit cargoLlvmCovExtraArgs cargoLlvmCovCommand;
+        LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
+        RUST_BACKTRACE = "full";
+      }
+    else if runTests then
       sharedArgsBase
       // {
         inherit cargoTestExtraArgs;
         doCheck = true;
-        LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
-        RUST_BACKTRACE = "full";
-      }
-    else if runCoverage then
-      sharedArgsBase
-      // {
-        inherit cargoLlvmCovExtraArgs cargoLlvmCovCommand;
         LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
         RUST_BACKTRACE = "full";
       }

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -27,8 +27,11 @@
   postInstall ? null, # Optional post-install script
   rev ? "unknown", # Git revision for version tracking
   runClippy ? false, # Whether to run Clippy linter
+  runCoverage ? false, # Whether to run code coverage
   runTests ? false, # Whether to run tests
   runBench ? false, # Whether to run benchmarks
+  cargoLlvmCovExtraArgs ? "--lcov --output-path $out", # Extra args for cargo-llvm-cov
+  cargoLlvmCovCommand ? "test", # Subcommand for cargo-llvm-cov (test, run, etc.)
   src, # Source tree
   stdenv, # Standard environment
   extraBuildInputs ? [ ], # Additional build inputs
@@ -62,6 +65,8 @@ let
   pname = crateInfo.pname;
   actualCargoProfile =
     if runTests then
+      "test"
+    else if runCoverage then
       "test"
     else if runClippy then
       "dev"
@@ -156,6 +161,13 @@ let
         LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
         RUST_BACKTRACE = "full";
       }
+    else if runCoverage then
+      sharedArgsBase
+      // {
+        inherit cargoLlvmCovExtraArgs cargoLlvmCovCommand;
+        LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
+        RUST_BACKTRACE = "full";
+      }
     else if runClippy then
       sharedArgsBase // { cargoClippyExtraArgs = "-- -Dwarnings"; }
     else
@@ -195,7 +207,9 @@ let
   };
 
   builder =
-    if runTests then
+    if runCoverage then
+      craneLib.cargoLlvmCov
+    else if runTests then
       craneLib.cargoTest
     else if runClippy then
       craneLib.cargoClippy

--- a/lib/shells.nix
+++ b/lib/shells.nix
@@ -6,6 +6,7 @@
 
 {
   pkgs,
+  pkgsUnstable ? pkgs, # Unstable nixpkgs (used for cargo-llvm-cov)
   crane,
   rustToolchain ? null, # Optional Rust toolchain override
   rustToolchainFile ? null, # Optional path to rust-toolchain.toml
@@ -16,6 +17,7 @@
   treefmtPrograms ? [ ], # Optional treefmt programs
   includePostgres ? false, # Whether to include PostgreSQL tools
   postgresPackage ? null, # Optional PostgreSQL package override
+  withLlvmTools ? false, # Whether to include llvm-tools for code coverage
 }:
 
 let
@@ -28,15 +30,19 @@ let
     else
       buildPlatform.config;
 
+  llvmToolsExtensions = if withLlvmTools then [ "llvm-tools-preview" ] else [ ];
+
   # Use provided Rust toolchain or default from rust-toolchain.toml or stable
   defaultRustToolchain =
     if rustToolchainFile != null then
       (pkgs.rust-bin.fromRustupToolchainFile rustToolchainFile).override {
         targets = [ cargoTarget ];
+        extensions = llvmToolsExtensions;
       }
     else
       (pkgs.rust-bin.stable.latest.default).override {
         targets = [ cargoTarget ];
+        extensions = llvmToolsExtensions;
       };
 
   finalRustToolchain = if rustToolchain != null then rustToolchain else defaultRustToolchain;
@@ -86,6 +92,9 @@ let
     cargo-audit # Rust security auditing
   ];
 
+  # Coverage packages (optional)
+  coveragePackages = if withLlvmTools then [ pkgsUnstable.cargo-llvm-cov ] else [ ];
+
   # CI/CD packages
   ciPackages = with pkgs; [
     lcov # Code coverage
@@ -98,7 +107,13 @@ let
 
   # All packages combined
   allPackages =
-    corePackages ++ ciPackages ++ postgresPackages ++ treefmtPackages ++ linuxPackages ++ extraPackages;
+    corePackages
+    ++ ciPackages
+    ++ coveragePackages
+    ++ postgresPackages
+    ++ treefmtPackages
+    ++ linuxPackages
+    ++ extraPackages;
 
   # Shell hook with Rust version display
   defaultShellHook = ''


### PR DESCRIPTION
## Summary

- Add Nix-cacheable code coverage builds using crane's `cargoLlvmCov`
- Introduce `localCoverage` builder with `llvm-tools` toolchain extension
- Provide overridable `cargoLlvmCovExtraArgs` and `cargoLlvmCovCommand` parameters

## Plan

### 1. Toolchain: `llvm-tools` extension (`rust-builder.nix`)
Add a `withLlvmTools` parameter that conditionally includes the `llvm-tools` Rust toolchain extension. This provides `llvm-profdata` and `llvm-cov` binaries required by `cargo-llvm-cov`. Works across stable, nightly, and `rust-toolchain.toml` configurations.

### 2. Coverage builder (`rust-builders.nix`)
Introduce `mkCoverageBuilder` and expose it as `localCoverage` in `mkAllBuilders`. This is a local builder with `withLlvmTools = true`, keeping the coverage toolchain separate from the default builder to avoid unnecessary cache invalidation.

### 3. Coverage build target (`rust-package.nix`)
Add `runCoverage` mode alongside the existing `runTests`, `runClippy`, `buildDocs`, and `runBench` modes. When enabled, uses `craneLib.cargoLlvmCov` as the builder. The coverage-specific arguments are overridable:
- `cargoLlvmCovExtraArgs` (default: `--lcov --output-path $out`) — controls output format
- `cargoLlvmCovCommand` (default: `test`) — controls the cargo subcommand

Coverage uses the `test` cargo profile, sets `LD_LIBRARY_PATH` for OpenSSL, and enables `RUST_BACKTRACE`.

### 4. API passthrough (`default.nix`)
Expose `withLlvmTools` in the `mkRustBuilder` API for users who create custom builders.

### 5. Example usage (`examples/rust-app/flake.nix`)
Demonstrate coverage as a flake check:
```nix
coverage = builders.localCoverage.callPackage lib.mkRustPackage {
  src = sources.test;
  depsSrc = sources.deps;
  cargoToml = ./Cargo.toml;
  inherit rev;
  runCoverage = true;
};
```

## Design decisions

- **Separate builder** (`localCoverage`) rather than always including `llvm-tools` — avoids changing the toolchain derivation hash for all existing builds
- **Nix-cacheable** — the coverage report is a pure Nix derivation, no shell escape needed
- **Overridable defaults** — users can switch to HTML output (`--html --output-dir $out`), change ignored patterns, or use a different subcommand

## Test plan

- [ ] Verify `nix-instantiate --parse` passes for all modified `.nix` files
- [ ] Build coverage target in the example app: `nix build .#checks.<system>.coverage`
- [ ] Verify LCOV output is produced at `$out`
- [ ] Test with custom `cargoLlvmCovExtraArgs` (e.g., HTML output)
- [ ] Confirm existing `local`, `localNightly`, and cross-compilation builders are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added code coverage support for Rust with LCOV report generation.
  * CI now runs a coverage check alongside tests and linting.
  * New builder preset enabling LLVM tooling to support coverage runs.
  * New configurable options to enable coverage and customize the coverage command/arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->