### PR TITLE
feat: add cargo bench --no-run and workspace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ package = builder.callPackage lib.mkRustPackage {
   runTests = false;          # Optional: run tests
   runClippy = false;         # Optional: run clippy
   buildDocs = false;         # Optional: build documentation
+  runBench = false;          # Optional: run benchmarks
+  buildBench = false;        # Optional: compile benchmarks (--no-run)
 };
 ```
 

--- a/examples/rust-app/flake.nix
+++ b/examples/rust-app/flake.nix
@@ -169,6 +169,15 @@
               runClippy = true;
             };
 
+            # Compile benchmarks (without running)
+            bench-compile = builders.local.callPackage lib.mkRustPackage {
+              src = sources.test;
+              depsSrc = sources.deps;
+              cargoToml = ./Cargo.toml;
+              inherit rev;
+              buildBench = true;
+            };
+
             # Formatting check
             formatting = config.treefmt.build.check self;
           };

--- a/lib/cargo-bench.nix
+++ b/lib/cargo-bench.nix
@@ -19,7 +19,8 @@ let
     "cargoExtraArgs"
   ];
 
-  noRunFlag = if noRun then "--no-run " else "";
+  benchCmd =
+    if noRun then "cargo bench --no-run --workspace --locked" else "cargo bench --workspace --locked";
 in
 # Create the benchmark derivation by extending the base cargo derivation
 # with benchmark-specific configuration
@@ -29,7 +30,7 @@ mkCargoDerivation (
     inherit cargoArtifacts;
     pnameSuffix = "-bench"; # Distinguish benchmark builds from regular builds
 
-    buildPhaseCargoCommand = "cargo bench ${noRunFlag}--workspace --locked";
+    buildPhaseCargoCommand = benchCmd;
 
     nativeBuildInputs = (args.nativeBuildInputs or [ ]);
   }

--- a/lib/cargo-bench.nix
+++ b/lib/cargo-bench.nix
@@ -5,6 +5,7 @@
 
 {
   mkCargoDerivation,
+  noRun ? false,
 }:
 
 {
@@ -17,6 +18,8 @@ let
   args = builtins.removeAttrs origArgs [
     "cargoExtraArgs"
   ];
+
+  noRunFlag = if noRun then "--no-run " else "";
 in
 # Create the benchmark derivation by extending the base cargo derivation
 # with benchmark-specific configuration
@@ -26,7 +29,7 @@ mkCargoDerivation (
     inherit cargoArtifacts;
     pnameSuffix = "-bench"; # Distinguish benchmark builds from regular builds
 
-    buildPhaseCargoCommand = "cargo bench --locked";
+    buildPhaseCargoCommand = "cargo bench ${noRunFlag}--workspace --locked";
 
     nativeBuildInputs = (args.nativeBuildInputs or [ ]);
   }

--- a/lib/rust-builder.nix
+++ b/lib/rust-builder.nix
@@ -105,7 +105,10 @@ let
   targetOpenssl = if isStatic then pkgs.pkgsStatic.openssl else pkgs.openssl;
   buildHostOpenssl = pkgsLocal.openssl;
   buildHostTarget =
-    if buildPlatform.config == "arm64-apple-darwin" then "aarch64-apple-darwin" else buildPlatform.config;
+    if buildPlatform.config == "arm64-apple-darwin" then
+      "aarch64-apple-darwin"
+    else
+      buildPlatform.config;
 
   buildEnvOpenssl =
     if isCross then

--- a/lib/rust-builder.nix
+++ b/lib/rust-builder.nix
@@ -116,6 +116,8 @@ let
         OPENSSL_NO_PKG_CONFIG = "1";
         "${envCase cargoTarget}_OPENSSL_LIB_DIR" = "${targetOpenssl.out}/lib";
         "${envCase cargoTarget}_OPENSSL_INCLUDE_DIR" = "${targetOpenssl.dev}/include";
+      }
+      // pkgsLocal.lib.optionalAttrs (buildHostTarget != cargoTarget) {
         "${envCase buildHostTarget}_OPENSSL_LIB_DIR" = "${buildHostOpenssl.out}/lib";
         "${envCase buildHostTarget}_OPENSSL_INCLUDE_DIR" = "${buildHostOpenssl.dev}/include";
       }

--- a/lib/rust-builders.nix
+++ b/lib/rust-builders.nix
@@ -81,6 +81,11 @@ rec {
   # Arguments: none
   mkX86_64DarwinBuilder =
     { }:
+    let
+      pkgsLocal = import nixpkgs { inherit localSystem; };
+      crossSystem = pkgsLocal.lib.systems.examples.x86_64-darwin;
+      isNative = pkgsLocal.lib.systems.equals (pkgsLocal.lib.systems.elaborate localSystem) crossSystem;
+    in
     import ./rust-builder.nix {
       inherit
         nixpkgs
@@ -88,9 +93,9 @@ rec {
         crane
         localSystem
         rustToolchainFile
+        crossSystem
         ;
-      crossSystem = (import nixpkgs { inherit localSystem; }).lib.systems.examples.x86_64-darwin;
-      isCross = true;
+      isCross = !isNative;
     };
 
   # Create a Rust builder for aarch64 macOS (Apple Silicon)
@@ -99,6 +104,11 @@ rec {
   # Arguments: none
   mkAarch64DarwinBuilder =
     { }:
+    let
+      pkgsLocal = import nixpkgs { inherit localSystem; };
+      crossSystem = pkgsLocal.lib.systems.examples.aarch64-darwin;
+      isNative = pkgsLocal.lib.systems.equals (pkgsLocal.lib.systems.elaborate localSystem) crossSystem;
+    in
     import ./rust-builder.nix {
       inherit
         nixpkgs
@@ -106,9 +116,9 @@ rec {
         crane
         localSystem
         rustToolchainFile
+        crossSystem
         ;
-      crossSystem = (import nixpkgs { inherit localSystem; }).lib.systems.examples.aarch64-darwin;
-      isCross = true;
+      isCross = !isNative;
     };
 
   # Helper function to create all platform builders at once

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -128,6 +128,8 @@ let
         cacert
       ];
 
+  opensslLibPath = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
+
   sharedArgsBase = {
     inherit pname pnameSuffix version;
     CARGO_PROFILE = actualCargoProfile;
@@ -158,7 +160,7 @@ let
       // {
         inherit cargoTestExtraArgs;
         doCheck = true;
-        LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
+        LD_LIBRARY_PATH = opensslLibPath;
         RUST_BACKTRACE = "full";
       }
     else if runClippy then
@@ -166,8 +168,7 @@ let
     else if runBench || buildBench then
       sharedArgsBase
       // {
-        doCheck = true;
-        LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
+        LD_LIBRARY_PATH = opensslLibPath;
         RUST_BACKTRACE = "full";
       }
     else
@@ -179,7 +180,7 @@ let
     cargoDocExtraArgs = "--workspace --no-deps";
     RUSTDOCFLAGS = "--enable-index-page -Z unstable-options -D warnings --document-private-items";
     CARGO_TARGET_DIR = "target/";
-    LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
+    LD_LIBRARY_PATH = opensslLibPath;
     postBuild = ''
       ${pandoc}/bin/pandoc -f markdown+hard_line_breaks -t html README.md > readme.html
       mv target/''${CARGO_BUILD_TARGET}/doc target/
@@ -208,11 +209,7 @@ let
 
   mkBench = import ./cargo-bench.nix {
     mkCargoDerivation = craneLib.mkCargoDerivation;
-  };
-
-  mkBenchNoRun = import ./cargo-bench.nix {
-    mkCargoDerivation = craneLib.mkCargoDerivation;
-    noRun = true;
+    noRun = buildBench;
   };
 
   builder =
@@ -222,9 +219,7 @@ let
       craneLib.cargoClippy
     else if buildDocs then
       craneLib.cargoDoc
-    else if buildBench then
-      mkBenchNoRun
-    else if runBench then
+    else if runBench || buildBench then
       mkBench
     else
       craneLib.buildPackage;

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -29,6 +29,7 @@
   runClippy ? false, # Whether to run Clippy linter
   runTests ? false, # Whether to run tests
   runBench ? false, # Whether to run benchmarks
+  buildBench ? false, # Whether to compile benchmarks without running (--no-run)
   src, # Source tree
   stdenv, # Standard environment
   extraBuildInputs ? [ ], # Additional build inputs
@@ -67,6 +68,8 @@ let
       "dev"
     else if buildDocs then
       "dev"
+    else if runBench || buildBench then
+      "bench"
     else
       CARGO_PROFILE;
   pnameSuffix = if actualCargoProfile == "release" then "" else "-${actualCargoProfile}";
@@ -158,6 +161,13 @@ let
       }
     else if runClippy then
       sharedArgsBase // { cargoClippyExtraArgs = "-- -Dwarnings"; }
+    else if runBench || buildBench then
+      sharedArgsBase
+      // {
+        doCheck = true;
+        LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
+        RUST_BACKTRACE = "full";
+      }
     else
       sharedArgsBase;
 
@@ -194,6 +204,11 @@ let
     mkCargoDerivation = craneLib.mkCargoDerivation;
   };
 
+  mkBenchNoRun = import ./cargo-bench.nix {
+    mkCargoDerivation = craneLib.mkCargoDerivation;
+    noRun = true;
+  };
+
   builder =
     if runTests then
       craneLib.cargoTest
@@ -201,6 +216,8 @@ let
       craneLib.cargoClippy
     else if buildDocs then
       craneLib.cargoDoc
+    else if buildBench then
+      mkBenchNoRun
     else if runBench then
       mkBench
     else


### PR DESCRIPTION
## Summary

Add support for `cargo bench --no-run` and `cargo bench` commands with workspace support.

- **`runBench ? false`** — compiles and runs benchmarks (`cargo bench --workspace --locked`)
- **`buildBench ? false`** — compiles benchmarks without running (`cargo bench --no-run --workspace --locked`), useful as a CI check

## Changes

### `lib/cargo-bench.nix`
- Added `noRun ? false` parameter to control `--no-run`
- Build command now uses `--workspace --locked` with explicit if/else for `--no-run` variant

### `lib/rust-package.nix`
- Added `buildBench ? false` parameter
- `actualCargoProfile` returns `"bench"` for both `runBench` and `buildBench`
- `sharedArgs` has a bench-specific branch with `LD_LIBRARY_PATH` and `RUST_BACKTRACE`
- Single `mkBench` import with `noRun = buildBench` (no duplicate imports)
- Builder selection: `runBench || buildBench` → `mkBench`
- Extracted `opensslLibPath` to deduplicate `LD_LIBRARY_PATH` across test/bench/docs

### `README.md`
- Added `runBench` and `buildBench` to the `mkRustPackage` API reference

### `examples/rust-app/flake.nix`
- Added a `bench-compile` check using `buildBench = true`

## Test plan

- [ ] Verify `buildBench = true` produces a derivation that runs `cargo bench --no-run --workspace --locked`
- [ ] Verify `runBench = true` produces a derivation that runs `cargo bench --workspace --locked`
- [ ] Verify `nix flake check` passes on a workspace with benchmarks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional benchmark compilation mode to compile benchmarks without execution
  * Implemented new benchmark-compile check in example workflow

* **Documentation**
  * Updated documentation with benchmark-related configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->