### PR TITLE
feat: Remove external dependency with flake-root at treefmt

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -204,6 +204,7 @@ rec {
       config,
       globalExcludes ? [ ],
       extraFormatters ? { },
+      projectRootFile ? "flake.nix",
     }:
     import ./treefmt.nix {
       inherit
@@ -211,6 +212,7 @@ rec {
         pkgs
         globalExcludes
         extraFormatters
+        projectRootFile
         ;
     };
 

--- a/lib/flake-module.nix
+++ b/lib/flake-module.nix
@@ -64,6 +64,13 @@
             };
           };
         };
+
+        projectRootFile = lib.mkOption {
+          type = lib.types.str;
+          default = "flake.nix";
+          description = "File used to identify the project root for treefmt";
+          example = "Cargo.toml";
+        };
       };
 
       # Apply configuration
@@ -73,6 +80,7 @@
           inherit config;
           globalExcludes = config.nix-lib.treefmt.globalExcludes;
           extraFormatters = config.nix-lib.treefmt.extraFormatters;
+          projectRootFile = config.nix-lib.treefmt.projectRootFile;
         };
 
         # Export the formatter for nix fmt

--- a/lib/treefmt.nix
+++ b/lib/treefmt.nix
@@ -64,6 +64,7 @@ let
 
     # Markdown and JSON formatting with Prettier
     programs.prettier.enable = true;
+    programs.prettier.package = pkgs.prettier;
     settings.formatter.prettier.includes = [
       "*.md"
       "*.json"

--- a/lib/treefmt.nix
+++ b/lib/treefmt.nix
@@ -11,6 +11,7 @@
   pkgs, # Nixpkgs package set
   globalExcludes ? [ ], # Additional global exclusions
   extraFormatters ? { }, # Additional formatter configurations
+  projectRootFile ? "flake.nix", # File to identify project root
 }:
 
 let
@@ -43,7 +44,7 @@ let
   # Base treefmt configuration
   baseConfig = {
     # Project root detection file
-    inherit (config.flake-root) projectRootFile;
+    inherit projectRootFile;
 
     # Global exclusions - files and directories to never format
     settings.global.excludes = allExcludes;


### PR DESCRIPTION
Removes external dependency with flake-root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to customize which marker file is used to detect the project root for the tree formatter. This lets users point the tool at alternative project manifest or marker files (e.g., package manifests) instead of the default, improving flexibility for non-standard project layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->