### PR TITLE
fix: Fix running tests for only binary

### DIFF
--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -215,10 +215,10 @@ let
       // {
         pname = pnameDeps;
         src = depsSrc;
-        # Override test args for deps: run --lib tests (which are empty stubs)
-        # to ensure all test artifacts including build.rs outputs are generated,
-        # without requiring actual integration test files in the dep source.
-        cargoTestExtraArgs = "--lib";
+        # Use --no-run to pre-compile test artifacts (including dev-dependencies
+        # and build.rs outputs) without running tests. --lib breaks binary-only
+        # crates that have no library target.
+        cargoTestExtraArgs = "--no-run";
       }
     );
   };


### PR DESCRIPTION
# Problem 
`mkRustPackage` with `runTests = true` calls `craneLib.buildDepsOnly` with `cargoTestExtraArgs = "--lib"` hardcoded. This causes `cargo test --lib` to run against the dummy source, which fails for binary-only crates with: "no library targets found in package".

# Root cause
 "--lib" assumes every package has a `[lib]` target. Crane's own default for this argument is "--no-run", which pre-compiles test artifacts without running them — sufficient for dev-dependency caching, and valid for all crate types.

# Fix 
Revert `cargoTestExtraArgs` in the `buildDepsOnly` call from "--lib" to "--no-run". This matches crane's original default, caches dev-dependencies correctly, and works for binary-only crates, library crates, and mixed packages.

# How to reproduce: 
Any `mkRustPackage` usage with `runTests = true` on a crate that has src/main.rs but no `src/lib.rs` and no `[lib]` section in `Cargo.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build system compatibility for binary-only crates by adjusting test compilation behavior during the build process. This resolves issues where certain crate configurations would previously fail during dependency building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->