### PR TITLE
fix: replace nixfmt-rfc-style with pkgs.nixfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ cross-compilation, Docker images, and comprehensive development environments.
 - **Cross-compilation**: Build Rust binaries for multiple platforms (Linux
   x86_64/ARM64, macOS x86_64/ARM64)
 - **Static linking**: Create fully static binaries with musl on Linux
-- **Library crates**: Build Rust library crates and install `.rlib`/`.a` artifacts
+- **Library crates**: Build Rust library crates and install `.rlib`/`.a`
+  artifacts
 - **Docker images**: Build optimized, layered container images
 - **Development shells**: Rich development environments with all necessary tools
 - **Code formatting**: Integrated treefmt configuration via flake module
@@ -206,7 +207,8 @@ These can be exposed as packages for `nix build` or as checks for
 #### `mkRustLibrary`
 
 Build a Rust library crate (a crate with `lib.rs` and no `main.rs`). The
-compiled `.rlib` and `.a` artifacts are installed to `$out/lib/`. Call via `builder.callPackage`.
+compiled `.rlib` and `.a` artifacts are installed to `$out/lib/`. Call via
+`builder.callPackage`.
 
 ```nix
 myLib = builder.callPackage lib.mkRustLibrary {
@@ -299,7 +301,7 @@ Import `nix-lib.flakeModules.default` to get automatic treefmt configuration:
 The module automatically configures formatters for:
 
 - Rust (rustfmt with nightly)
-- Nix (nixfmt-rfc-style)
+- Nix (nixfmt)
 - TOML (taplo with alignment and sorting)
 - YAML (yamlfmt)
 - JSON and Markdown (prettier)
@@ -589,7 +591,6 @@ nix build -L .#integration-tests
 
 # Run unit tests with nightly toolchain
 nix build -L .#unit-tests-nightly
-
 ```
 
 ## Platform Support

--- a/examples/rust-app/README.md
+++ b/examples/rust-app/README.md
@@ -65,7 +65,6 @@ nix fmt
 ```bash
 # Build Docker image
 nix build .#docker
-
 ```
 
 ### Quality Checks

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
             # Development shell for working on the library itself
             devShells.default = pkgs.mkShell {
               buildInputs = with pkgs; [
-                nixfmt-rfc-style
+                nixfmt
                 nil # Nix language server
                 deno # For markdown formatting
                 just
@@ -130,7 +130,7 @@
               programs = {
                 nixfmt = {
                   enable = true;
-                  package = pkgs.nixfmt-rfc-style;
+                  package = pkgs.nixfmt;
                 };
                 deno = {
                   enable = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and readability of project documentation with adjusted line wrapping for configuration sections and feature descriptions
  * Cleaned up minor whitespace inconsistencies in example documentation

* **Chores**
  * Updated development environment and build tool configuration to use an updated Nix formatter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->