### PR TITLE
fix(shells): source cargo-audit from nixpkgs-unstable

### DIFF
--- a/lib/shells.nix
+++ b/lib/shells.nix
@@ -6,7 +6,7 @@
 
 {
   pkgs,
-  pkgsUnstable ? pkgs, # Unstable nixpkgs (used for cargo-llvm-cov)
+  pkgsUnstable ? pkgs, # Unstable nixpkgs (used for cargo-audit, cargo-llvm-cov)
   crane,
   rustToolchain ? null, # Optional Rust toolchain override
   rustToolchainFile ? null, # Optional path to rust-toolchain.toml
@@ -88,8 +88,8 @@ let
     time
     which
 
-    # Rust tooling
-    cargo-audit # Rust security auditing
+    # Rust tooling (cargo-audit from unstable for latest advisory support)
+    pkgsUnstable.cargo-audit
   ];
 
   # Coverage packages (optional)


### PR DESCRIPTION
## Summary

- Source `cargo-audit` from `pkgsUnstable` instead of `pkgs` in `mkDevShell`'s `corePackages`
- Consistent with how `cargo-llvm-cov` is already sourced from unstable (`shells.nix:96`) and how `mkAuditApp` defaults to `pkgsUnstable.cargo-audit` (`apps.nix:50`)

### Why

The stable nixpkgs `cargo-audit` can lag behind on advisory DB format support. As noted in `apps.nix:45`:

> new advisory DB entries require at least version 0.22

Consumers currently work around this by adding `pkgs-unstable.cargo-audit` to `extraPackages`, but it gets shadowed by `corePackages` in PATH since `corePackages` comes first. This change fixes the source directly.

### Impact

All consumers of `mkDevShell` get the latest `cargo-audit` from unstable automatically. Consumers that were adding `pkgs-unstable.cargo-audit` via `extraPackages` can remove it after bumping nix-lib.

Refs #19, #20