### PR TITLE
feat(shells): Allow to create shell without ci tools

### DIFF
--- a/.actionlint.yaml
+++ b/.actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - depot-ubuntu-24.04

--- a/.github/workflows/nix-checks.yaml
+++ b/.github/workflows/nix-checks.yaml
@@ -1,0 +1,24 @@
+name: Nix Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: nix-checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flake-check:
+    name: Run flake checks
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Run nix flake check
+        uses: hoprnet/hopr-workflows/actions/nix-action@nix-action-v1
+        with:
+          source_branch: ${{ github.head_ref || github.ref_name }}
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          command: nix flake check -L

--- a/README.md
+++ b/README.md
@@ -266,11 +266,16 @@ devShell = lib.mkDevShell {
   shellName = "My Project";
   extraPackages = [ pkgs.postgresql ];
   includePostgres = true;
+  includeCiPackages = false; # Optional: exclude CI-only tools for lean local shells
   shellHook = ''
     echo "Welcome to my project!"
   '';
 };
 ```
+
+`mkDevShell` includes CI/CD tools by default for backward compatibility. Set
+`includeCiPackages = false;` to exclude CI packages from local development
+shells.
 
 ### Code Formatting
 

--- a/flake.nix
+++ b/flake.nix
@@ -92,14 +92,7 @@
           }:
           let
             lib = libForSystem system;
-            ciToolNames = [
-              "lcov"
-              "skopeo"
-              "dive"
-              "go-containerregistry"
-              "shellcheck"
-              "shfmt"
-            ];
+            ciToolNames = lib.ciTools.names;
             devShellWithCi = lib.mkDevShell { };
             devShellWithoutCi = lib.mkDevShell {
               includeCiPackages = false;

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,25 @@
           }:
           let
             lib = libForSystem system;
+            ciToolNames = [
+              "lcov"
+              "skopeo"
+              "dive"
+              "go-containerregistry"
+              "shellcheck"
+              "shfmt"
+            ];
+            devShellWithCi = lib.mkDevShell { };
+            devShellWithoutCi = lib.mkDevShell {
+              includeCiPackages = false;
+            };
+            hasToolInShell =
+              shell: toolName:
+              builtins.any (path: pkgs.lib.hasInfix "-${toolName}-" path) (
+                shell.inputDerivation.nativeBuildInputs or [ ]
+              );
+            allCiToolsInShell = shell: builtins.all (toolName: hasToolInShell shell toolName) ciToolNames;
+            noCiToolsInShell = shell: builtins.all (toolName: !(hasToolInShell shell toolName)) ciToolNames;
           in
           {
             # Import nixpkgs with overlays
@@ -186,6 +205,22 @@
             checks = {
               # Formatting check
               format = config.treefmt.build.check self;
+
+              # Default mkDevShell should include CI tooling (backward compatibility)
+              devShellCiPackagesDefault =
+                assert pkgs.lib.assertMsg (allCiToolsInShell devShellWithCi)
+                  "mkDevShell default is expected to include CI packages";
+                pkgs.runCommand "check-dev-shell-ci-packages-default" { } ''
+                  touch "$out"
+                '';
+
+              # mkDevShell with includeCiPackages = false should exclude CI tooling
+              devShellCiPackagesDisabled =
+                assert pkgs.lib.assertMsg (noCiToolsInShell devShellWithoutCi)
+                  "mkDevShell with includeCiPackages = false is expected to exclude CI packages";
+                pkgs.runCommand "check-dev-shell-ci-packages-disabled" { } ''
+                  touch "$out"
+                '';
             };
           };
 

--- a/lib/ci-tools.nix
+++ b/lib/ci-tools.nix
@@ -1,0 +1,20 @@
+{
+  names = [
+    "lcov"
+    "skopeo"
+    "dive"
+    "go-containerregistry"
+    "shellcheck"
+    "shfmt"
+  ];
+
+  mkPackages =
+    pkgs: with pkgs; [
+      lcov # Code coverage
+      skopeo # Container image tools
+      dive # Docker layer analysis
+      go-containerregistry # OCI image manipulation tool (includes crane and gcrane)
+      shellcheck # Shell script linting
+      shfmt # Shell script formatting
+    ];
+}

--- a/lib/ci-tools.nix
+++ b/lib/ci-tools.nix
@@ -1,4 +1,4 @@
-{
+rec {
   names = [
     "lcov"
     "skopeo"
@@ -8,13 +8,5 @@
     "shfmt"
   ];
 
-  mkPackages =
-    pkgs: with pkgs; [
-      lcov # Code coverage
-      skopeo # Container image tools
-      dive # Docker layer analysis
-      go-containerregistry # OCI image manipulation tool (includes crane and gcrane)
-      shellcheck # Shell script linting
-      shfmt # Shell script formatting
-    ];
+  mkPackages = pkgs: map (name: builtins.getAttr name pkgs) names;
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -175,6 +175,7 @@ rec {
       includePostgres ? false,
       postgresPackage ? null,
       withLlvmTools ? false,
+      includeCiPackages ? true,
     }:
     import ./shells.nix {
       inherit
@@ -190,6 +191,7 @@ rec {
         includePostgres
         postgresPackage
         withLlvmTools
+        includeCiPackages
         ;
       pkgsUnstable = pkgsUnstable;
     };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -36,6 +36,8 @@ let
   lib = pkgs.lib;
 in
 rec {
+  ciTools = import ./ci-tools.nix;
+
   # Source Filtering
   # ---------------
   # Functions for creating filtered source trees for different build contexts
@@ -181,6 +183,7 @@ rec {
       inherit
         pkgs
         crane
+        ciTools
         rustToolchain
         rustToolchainFile
         extraPackages

--- a/lib/shells.nix
+++ b/lib/shells.nix
@@ -18,6 +18,7 @@
   includePostgres ? false, # Whether to include PostgreSQL tools
   postgresPackage ? null, # Optional PostgreSQL package override
   withLlvmTools ? false, # Whether to include llvm-tools for code coverage
+  includeCiPackages ? true, # Whether to include CI/CD tooling
 }:
 
 let
@@ -96,14 +97,19 @@ let
   coveragePackages = if withLlvmTools then [ pkgsUnstable.cargo-llvm-cov ] else [ ];
 
   # CI/CD packages
-  ciPackages = with pkgs; [
-    lcov # Code coverage
-    skopeo # Container image tools
-    dive # Docker layer analysis
-    go-containerregistry # OCI image manipulation tool (includes crane and gcrane)
-    shellcheck # Shell script linting
-    shfmt # Shell script formatting
-  ];
+  ciPackages =
+    if includeCiPackages then
+      with pkgs;
+      [
+        lcov # Code coverage
+        skopeo # Container image tools
+        dive # Docker layer analysis
+        go-containerregistry # OCI image manipulation tool (includes crane and gcrane)
+        shellcheck # Shell script linting
+        shfmt # Shell script formatting
+      ]
+    else
+      [ ];
 
   # All packages combined
   allPackages =

--- a/lib/shells.nix
+++ b/lib/shells.nix
@@ -8,6 +8,7 @@
   pkgs,
   pkgsUnstable ? pkgs, # Unstable nixpkgs (used for cargo-audit, cargo-llvm-cov)
   crane,
+  ciTools,
   rustToolchain ? null, # Optional Rust toolchain override
   rustToolchainFile ? null, # Optional path to rust-toolchain.toml
   extraPackages ? [ ], # Additional packages to include
@@ -97,19 +98,7 @@ let
   coveragePackages = if withLlvmTools then [ pkgsUnstable.cargo-llvm-cov ] else [ ];
 
   # CI/CD packages
-  ciPackages =
-    if includeCiPackages then
-      with pkgs;
-      [
-        lcov # Code coverage
-        skopeo # Container image tools
-        dive # Docker layer analysis
-        go-containerregistry # OCI image manipulation tool (includes crane and gcrane)
-        shellcheck # Shell script linting
-        shfmt # Shell script formatting
-      ]
-    else
-      [ ];
+  ciPackages = if includeCiPackages then ciTools.mkPackages pkgs else [ ];
 
   # All packages combined
   allPackages =


### PR DESCRIPTION
This allows users of nix-lib to create leaner devshells.

Fixes #19 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mkDevShell option to opt out of including CI/CD tools in local dev shells.

* **Documentation**
  * Updated README to document the new CI package inclusion option and example usage.

* **Chores**
  * Added automated Nix flake validation workflow to CI and updated runner matching for self-hosted runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->