### PR TITLE
feat: Add specific containers format version to skopeo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -114,12 +114,14 @@
               ];
             };
 
-            # Skopeo wrapper that ensures /etc/containers/registries.conf is in v2 format.
+            # Skopeo wrapper that ensures ~/.config/containers/registries.conf is in v2 format.
             # Ubuntu 22.04/24.04 runners ship a v1 file that newer skopeo rejects.
             # Usage in CI: nix shell github:hoprnet/nix-lib#skopeo -c bash
             packages.skopeo = pkgs.writeShellScriptBin "skopeo" ''
               mkdir -p "''${HOME}/.config/containers"
-              printf 'unqualified-search-registries = ["docker.io"]\n' > "''${HOME}/.config/containers/registries.conf"
+              if [ ! -e "''${HOME}/.config/containers/registries.conf" ]; then
+                printf 'unqualified-search-registries = ["docker.io"]\n' > "''${HOME}/.config/containers/registries.conf"
+              fi
               exec ${pkgs.skopeo}/bin/skopeo "$@"
             '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -107,7 +107,7 @@
             # Usage in CI: nix shell github:hoprnet/nix-lib#skopeo -c bash
             packages.skopeo = pkgs.writeShellScriptBin "skopeo" ''
               mkdir -p "''${HOME}/.config/containers"
-              printf 'unqualified-search-registries = []\n' > "''${HOME}/.config/containers/registries.conf"
+              printf 'unqualified-search-registries = ["docker.io"]\n' > "''${HOME}/.config/containers/registries.conf"
               exec ${pkgs.skopeo}/bin/skopeo "$@"
             '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,15 @@
               ];
             };
 
+            # Skopeo wrapper that ensures /etc/containers/registries.conf is in v2 format.
+            # Ubuntu 22.04/24.04 runners ship a v1 file that newer skopeo rejects.
+            # Usage in CI: nix shell github:hoprnet/nix-lib#skopeo -c bash
+            packages.skopeo = pkgs.writeShellScriptBin "skopeo" ''
+              mkdir -p "''${HOME}/.config/containers"
+              printf 'unqualified-search-registries = []\n' > "''${HOME}/.config/containers/registries.conf"
+              exec ${pkgs.skopeo}/bin/skopeo "$@"
+            '';
+
             # Development shell for working on the library itself
             devShells.default = pkgs.mkShell {
               buildInputs = with pkgs; [

--- a/lib/shells.nix
+++ b/lib/shells.nix
@@ -121,6 +121,8 @@ let
     echo "   Rust version: $(rustc --version)"
     echo "   Cargo version: $(cargo --version)"
     echo ""
+    mkdir -p "''${HOME}/.config/containers"
+    printf 'unqualified-search-registries = []\n' > "''${HOME}/.config/containers/registries.conf"
   '';
 
   finalShellHook = defaultShellHook + shellHook;

--- a/lib/shells.nix
+++ b/lib/shells.nix
@@ -117,7 +117,9 @@ let
     echo "   Cargo version: $(cargo --version)"
     echo ""
     mkdir -p "''${HOME}/.config/containers"
-    printf 'unqualified-search-registries = ["docker.io"]\n' > "''${HOME}/.config/containers/registries.conf"
+    if [ ! -e "''${HOME}/.config/containers/registries.conf" ]; then
+      printf 'unqualified-search-registries = ["docker.io"]\n' > "''${HOME}/.config/containers/registries.conf"
+    fi
   '';
 
   finalShellHook = defaultShellHook + shellHook;

--- a/lib/shells.nix
+++ b/lib/shells.nix
@@ -122,7 +122,7 @@ let
     echo "   Cargo version: $(cargo --version)"
     echo ""
     mkdir -p "''${HOME}/.config/containers"
-    printf 'unqualified-search-registries = []\n' > "''${HOME}/.config/containers/registries.conf"
+    printf 'unqualified-search-registries = ["docker.io"]\n' > "''${HOME}/.config/containers/registries.conf"
   '';
 
   finalShellHook = defaultShellHook + shellHook;


### PR DESCRIPTION
Latest versions of skopeo requires to use v2 format from containers registry config.
A nix package `skopeo` is provided to be able to use skopeo with this containers registry format.
It is also included in the shell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container registry configuration compatibility for development and CI environments
  * Enhanced container configuration management in development shells

<!-- end of auto-generated comment: release notes by coderabbit.ai -->