### PR TITLE
fix(docker): use ambient pkgs for Linux hosts in mkDockerImage

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -130,14 +130,19 @@ rec {
       extraContents ? [ ],
       basePackages ? null,
       tag ? "latest",
-      pkgsLinux ? null, # Optional Linux pkgs for building on macOS
+      pkgsLinux ? null, # Optional Linux pkgs override (e.g. for building on macOS)
       pathsToLink ? [ "/bin" ],
     }:
     let
-      # Use provided Linux packages or create new ones
+      # Prefer an explicit override, then the ambient pkgs if it's already
+      # Linux (covers native x86_64-linux and aarch64-linux runners), and
+      # only fall back to a cross-imported x86_64-linux nixpkgs when the
+      # ambient system can't build Linux Docker images at all (e.g. Darwin).
       actualPkgs =
         if pkgsLinux != null then
           pkgsLinux
+        else if pkgs.stdenv.isLinux then
+          pkgs
         else
           import nixpkgs {
             system = "x86_64-linux";


### PR DESCRIPTION
## Summary
- `mkDockerImage` always cross-imported a fresh nixpkgs pinned to `system = "x86_64-linux"` for its Docker image-packing tooling, unless callers passed `pkgsLinux` explicitly.
- That accidentally worked when builds ran on x86_64-linux runners, but fails outright on native aarch64-linux runners with `required system: x86_64-linux`, since there's no way to satisfy that requirement there.
- Now the ambient `pkgs` is used whenever the host is already Linux (any arch), falling back to the x86_64-linux cross-import only for non-Linux hosts (e.g. building from macOS), which is unchanged.

This was found while fixing `hoprnet/hoprd`'s `merge.yaml` pipeline: the aarch64 Docker build leg needed to move to a native ARM runner (`depot-ubuntu-24.04-arm-4`) to hit the Cachix binary cache instead of cross-compiling the whole Rust workspace from scratch — but that runner change then hit this `mkDockerImage` bug.

## Test plan
- [x] `nix-instantiate --parse lib/default.nix`
- [x] `nix fmt lib/default.nix` (0 changes — already formatted)
- [ ] Verify in `hoprnet/hoprd` merge pipeline once this is merged and `flake.lock` is bumped: aarch64 Docker build should succeed on the native ARM runner without the "required system: x86_64-linux" error
