### PR TITLE
fix(ci): improve dependency caching and Nextest support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,8 @@ The library is organized as a flake that exposes functions through
 #### Rust Package Builder (`rust-package.nix`)
 
 - **Low-level builder**: Called via `builder.callPackage` from consumer projects
-- **Multi-mode**: Supports release builds, tests (runTests), clippy (runClippy),
-  docs (buildDocs), and benchmarks (runBench)
+- **Multi-mode**: Supports release builds, tests (runTests), Nextest
+  (runNextest), clippy (runClippy), docs (buildDocs), and benchmarks (runBench)
 - **Configurable test arguments**: The `cargoTestExtraArgs` parameter (default:
   `"--workspace"`) controls what flags are passed to `cargo test`. This enables
   splitting unit tests (`--lib`) and integration tests (`--test '*'`) into

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ package = builder.callPackage lib.mkRustPackage {
   CARGO_PROFILE = "release"; # Optional: release/dev/test
   runTests = false;          # Optional: run tests
   cargoTestExtraArgs = "--workspace";  # Optional: args for cargo test
+  runNextest = false;        # Optional: run tests with cargo-nextest
+  cargoNextestExtraArgs = ""; # Optional: additional args for cargo nextest
   prependPackageName = true;           # Optional: prepend -p ${pname} to cargo args
   runClippy = false;         # Optional: run clippy
   buildDocs = false;         # Optional: build documentation
@@ -203,6 +205,23 @@ integration-tests = builder.callPackage lib.mkRustPackage {
 
 These can be exposed as packages for `nix build` or as checks for
 `nix flake check`.
+
+##### Running Tests with Nextest
+
+Nextest tests use the same dependency-only derivation as other Rust package
+modes, so their Cargo artifacts can be reused from a Nix binary cache.
+
+```nix
+nextest = builder.callPackage lib.mkRustPackage {
+  src = sources.test;
+  depsSrc = sources.deps;
+  cargoToml = ./Cargo.toml;
+  rev = "v1.0.0";
+  runNextest = true;
+  prependPackageName = false;
+  cargoExtraArgs = "--workspace";
+};
+```
 
 #### `mkRustLibrary`
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,10 @@ package = builder.callPackage lib.mkRustPackage {
   depsSrc = sources.deps;
   cargoToml = ./Cargo.toml;
   rev = "v1.0.0";
+  buildVersion = "1.0.0+commit.abcdef0"; # Optional: final artifact only
   CARGO_PROFILE = "release"; # Optional: release/dev/test
   runTests = false;          # Optional: run tests
+  testCargoProfile = "test"; # Optional: profile for tests and coverage
   cargoTestExtraArgs = "--workspace";  # Optional: args for cargo test
   runNextest = false;        # Optional: run tests with cargo-nextest
   cargoNextestExtraArgs = ""; # Optional: additional args for cargo nextest
@@ -174,6 +176,11 @@ package = builder.callPackage lib.mkRustPackage {
   buildBench = false;        # Optional: compile benchmarks (--no-run)
 };
 ```
+
+When `buildVersion` is set, `BUILD_VERSION` is available while compiling the
+final artifact but is deliberately excluded from the dependency-only derivation.
+Consumers can use `option_env!("BUILD_VERSION")` and fall back to
+`env!("CARGO_PKG_VERSION")` for local builds.
 
 ##### Splitting Unit and Integration Tests
 
@@ -209,7 +216,10 @@ These can be exposed as packages for `nix build` or as checks for
 ##### Running Tests with Nextest
 
 Nextest tests use the same dependency-only derivation as other Rust package
-modes, so their Cargo artifacts can be reused from a Nix binary cache.
+modes, so their Cargo artifacts can be reused from a Nix binary cache. Test
+dependencies are prepared in one `cargo test --no-run --lib` pass. The final
+test derivation stores only its success result rather than archiving its Cargo
+target directory; the reusable artifacts remain in the dependency derivation.
 
 ```nix
 nextest = builder.callPackage lib.mkRustPackage {
@@ -223,11 +233,15 @@ nextest = builder.callPackage lib.mkRustPackage {
 };
 ```
 
+The same lightweight final output is used for `runTests` and `runClippy`
+derivations.
+
 #### `mkRustLibrary`
 
 Build a Rust library crate (a crate with `lib.rs` and no `main.rs`). The
 compiled `.rlib` and `.a` artifacts are installed to `$out/lib/`. Call via
-`builder.callPackage`.
+`builder.callPackage`. Its test and Clippy modes also keep reusable Cargo
+artifacts exclusively in the dependency derivation.
 
 ```nix
 myLib = builder.callPackage lib.mkRustLibrary {
@@ -237,6 +251,7 @@ myLib = builder.callPackage lib.mkRustLibrary {
   rev = "v1.0.0";
   CARGO_PROFILE = "release"; # Optional: release/dev/test (default: release)
   runTests = false;          # Optional: run tests
+  testCargoProfile = "test"; # Optional: profile used when runTests is enabled
   runClippy = false;         # Optional: run clippy
 };
 

--- a/examples/rust-app/flake.nix
+++ b/examples/rust-app/flake.nix
@@ -115,6 +115,15 @@
             builder = builders.localNightly;
             cargoTestExtraArgs = "--lib";
           };
+          nextest = builders.local.callPackage lib.mkRustPackage {
+            src = sources.test;
+            depsSrc = sources.deps;
+            cargoToml = ./Cargo.toml;
+            inherit rev;
+            runNextest = true;
+            prependPackageName = false;
+            cargoExtraArgs = "--workspace";
+          };
 
         in
         {
@@ -141,6 +150,7 @@
               integration-tests
               test-nightly
               unit-tests-nightly
+              nextest
               ;
           };
 
@@ -185,6 +195,7 @@
               integration-tests
               test-nightly
               unit-tests-nightly
+              nextest
               ;
 
             # Run clippy linter

--- a/lib/rust-library.nix
+++ b/lib/rust-library.nix
@@ -7,6 +7,7 @@
 #   builder.callPackage lib.mkRustLibrary { ... }
 
 {
+  buildVersion ? null, # Optional final-artifact version exposed as BUILD_VERSION
   CARGO_PROFILE ? "release", # Cargo build profile (release/dev/etc)
   cargoExtraArgs ? "", # Additional arguments for cargo build
   cargoToml, # Path to the Cargo.toml file
@@ -24,6 +25,7 @@
   rev ? "unknown", # Git revision for version tracking
   runClippy ? false, # Whether to run Clippy linter
   runTests ? false, # Whether to run tests
+  testCargoProfile ? "test", # Cargo profile used by test mode
   src, # Source tree
   stdenv, # Standard environment
   extraBuildInputs ? [ ], # Additional build inputs
@@ -51,7 +53,7 @@ let
 
   actualCargoProfile =
     if runTests then
-      "test"
+      testCargoProfile
     else if runClippy then
       "dev"
     else
@@ -129,7 +131,8 @@ let
     strictDeps = true;
     doCheck = false;
     VERGEN_GIT_SHA = rev;
-  };
+  }
+  // lib.optionalAttrs (buildVersion != null) { BUILD_VERSION = buildVersion; };
 
   sharedArgs =
     if runTests then
@@ -137,22 +140,39 @@ let
       // {
         cargoTestExtraArgs = "--workspace";
         doCheck = true;
+        doInstallCargoArtifacts = false;
         LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
         RUST_BACKTRACE = "full";
       }
     else if runClippy then
-      sharedArgsBase // { cargoClippyExtraArgs = "-- -Dwarnings"; }
+      sharedArgsBase
+      // {
+        cargoClippyExtraArgs = "-- -Dwarnings";
+        doInstallCargoArtifacts = false;
+      }
     else
       sharedArgsBase;
 
+  depsOnlyArgs =
+    builtins.removeAttrs sharedArgs [
+      "BUILD_VERSION"
+      "VERGEN_GIT_SHA"
+      "doInstallCargoArtifacts"
+    ]
+    // {
+      pname = pnameDeps;
+      src = depsSrc;
+    }
+    // lib.optionalAttrs runTests {
+      buildPhaseCargoCommand = "";
+      cargoTestExtraArgs = "--no-run --lib";
+    }
+    // lib.optionalAttrs runClippy {
+      buildPhaseCargoCommand = "cargoWithProfile check ${sharedArgs.cargoExtraArgs}";
+    };
+
   defaultArgs = {
-    cargoArtifacts = craneLib.buildDepsOnly (
-      sharedArgs
-      // {
-        pname = pnameDeps;
-        src = depsSrc;
-      }
-    );
+    cargoArtifacts = craneLib.buildDepsOnly depsOnlyArgs;
   };
 
   args = sharedArgs // defaultArgs;

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -257,13 +257,20 @@ let
       buildPhaseCargoCommand = ''
         eval "$(cargo llvm-cov show-env --sh)"
         ${
-          if cargoLlvmCovCommand == "test" || cargoLlvmCovCommand == "nextest" then
+          if cargoLlvmCovCommand == "nextest" then
+            "cargo nextest run --cargo-profile ${actualCargoProfile} ${sharedArgs.cargoExtraArgs} --no-run"
+          else if cargoLlvmCovCommand == "test" then
             "cargoWithProfile test ${sharedArgs.cargoExtraArgs} --no-run"
           else
             "cargoWithProfile build ${sharedArgs.cargoExtraArgs}"
         }
       '';
       checkPhaseCargoCommand = "";
+    }
+    // lib.optionalAttrs (runCoverage && cargoLlvmCovCommand == "nextest") {
+      # The final coverage derivation passes the Cargo profile explicitly to
+      # nextest. Keep the dependency build's environment identical.
+      CARGO_PROFILE = "";
     }
     // lib.optionalAttrs (runTests || runNextest) {
       # A single no-run test build prepares normal and dev dependencies,

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -10,6 +10,7 @@
   buildDocs ? false, # Whether to build documentation
   CARGO_PROFILE ? "release", # Cargo build profile (release/dev/etc)
   cargoExtraArgs ? "", # Additional arguments for cargo build
+  cargoNextestExtraArgs ? "", # Additional arguments for cargo nextest
   cargoTestExtraArgs ? "--workspace", # Additional arguments for cargo test (before --)
   prependPackageName ? true, # When true, prepend -p ${pname} to cargoExtraArgs
   cargoToml, # Path to the Cargo.toml file
@@ -30,6 +31,7 @@
   rev ? "unknown", # Git revision for version tracking
   runClippy ? false, # Whether to run Clippy linter
   runCoverage ? false, # Whether to run code coverage
+  runNextest ? false, # Whether to run tests with cargo-nextest
   runTests ? false, # Whether to run tests
   runBench ? false, # Whether to run benchmarks
   buildBench ? false, # Whether to compile benchmarks without running (--no-run)
@@ -68,6 +70,8 @@ let
   pname = crateInfo.pname;
   actualCargoProfile =
     if runCoverage then
+      "test"
+    else if runNextest then
       "test"
     else if runTests then
       "test"
@@ -173,6 +177,14 @@ let
         LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
         RUST_BACKTRACE = "full";
       }
+    else if runNextest then
+      sharedArgsBase
+      // {
+        inherit cargoNextestExtraArgs;
+        doCheck = true;
+        LD_LIBRARY_PATH = opensslLibPath;
+        RUST_BACKTRACE = "full";
+      }
     else if runTests then
       sharedArgsBase
       // {
@@ -233,6 +245,8 @@ let
   builder =
     if runCoverage then
       craneLib.cargoLlvmCov
+    else if runNextest then
+      craneLib.cargoNextest
     else if runTests then
       craneLib.cargoTest
     else if runClippy then

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -8,6 +8,7 @@
 
 {
   buildDocs ? false, # Whether to build documentation
+  buildVersion ? null, # Optional final-artifact version exposed as BUILD_VERSION
   CARGO_PROFILE ? "release", # Cargo build profile (release/dev/etc)
   cargoExtraArgs ? "", # Additional arguments for cargo build
   cargoNextestExtraArgs ? "", # Additional arguments for cargo nextest
@@ -33,6 +34,7 @@
   runCoverage ? false, # Whether to run code coverage
   runNextest ? false, # Whether to run tests with cargo-nextest
   runTests ? false, # Whether to run tests
+  testCargoProfile ? "test", # Cargo profile used by test and coverage modes
   runBench ? false, # Whether to run benchmarks
   buildBench ? false, # Whether to compile benchmarks without running (--no-run)
   cargoLlvmCovExtraArgs ? "--lcov --output-path $out", # Extra args for cargo-llvm-cov
@@ -70,11 +72,11 @@ let
   pname = crateInfo.pname;
   actualCargoProfile =
     if runCoverage then
-      "test"
+      testCargoProfile
     else if runNextest then
-      "test"
+      testCargoProfile
     else if runTests then
-      "test"
+      testCargoProfile
     else if runClippy then
       "dev"
     else if buildDocs then
@@ -167,7 +169,8 @@ let
     doCheck = false;
     # set to the revision because during build the Git info is not available
     VERGEN_GIT_SHA = rev;
-  };
+  }
+  // lib.optionalAttrs (buildVersion != null) { BUILD_VERSION = buildVersion; };
 
   sharedArgs =
     if runCoverage then
@@ -182,6 +185,7 @@ let
       // {
         inherit cargoNextestExtraArgs;
         doCheck = true;
+        doInstallCargoArtifacts = false;
         LD_LIBRARY_PATH = opensslLibPath;
         RUST_BACKTRACE = "full";
       }
@@ -190,11 +194,16 @@ let
       // {
         inherit cargoTestExtraArgs;
         doCheck = true;
+        doInstallCargoArtifacts = false;
         LD_LIBRARY_PATH = opensslLibPath;
         RUST_BACKTRACE = "full";
       }
     else if runClippy then
-      sharedArgsBase // { cargoClippyExtraArgs = "-- -Dwarnings"; }
+      sharedArgsBase
+      // {
+        cargoClippyExtraArgs = "-- -Dwarnings";
+        doInstallCargoArtifacts = false;
+      }
     else if runBench || buildBench then
       sharedArgsBase
       // {
@@ -221,18 +230,31 @@ let
     '';
   };
 
+  depsOnlyArgs =
+    builtins.removeAttrs sharedArgs [
+      "BUILD_VERSION"
+      "VERGEN_GIT_SHA"
+      "doInstallCargoArtifacts"
+    ]
+    // {
+      pname = pnameDeps;
+      src = depsSrc;
+    }
+    // lib.optionalAttrs (runTests || runNextest) {
+      # A single no-run test build prepares normal and dev dependencies,
+      # including build-script outputs, without compiling the dependency graph
+      # separately through cargo check and cargo build first.
+      buildPhaseCargoCommand = "";
+      cargoTestExtraArgs = "--no-run --lib";
+    }
+    // lib.optionalAttrs runClippy {
+      # Clippy only reuses cargo check artifacts; a separate cargo build adds
+      # no reusable work for the final lint derivation.
+      buildPhaseCargoCommand = "cargoWithProfile check ${sharedArgs.cargoExtraArgs}";
+    };
+
   defaultArgs = {
-    cargoArtifacts = craneLib.buildDepsOnly (
-      builtins.removeAttrs sharedArgs [ "VERGEN_GIT_SHA" ]
-      // {
-        pname = pnameDeps;
-        src = depsSrc;
-        # Override test args for deps: run --lib tests (which are empty stubs)
-        # to ensure all test artifacts including build.rs outputs are generated,
-        # without requiring actual integration test files in the dep source.
-        cargoTestExtraArgs = "--lib";
-      }
-    );
+    cargoArtifacts = craneLib.buildDepsOnly depsOnlyArgs;
   };
 
   args = if buildDocs then sharedArgs // docsArgs else sharedArgs // defaultArgs;

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -176,7 +176,16 @@ let
     if runCoverage then
       sharedArgsBase
       // {
-        inherit cargoLlvmCovExtraArgs cargoLlvmCovCommand;
+        inherit cargoLlvmCovCommand;
+        # Keep the instrumented dependency artifacts restored from
+        # buildDepsOnly. Each Nix build starts from a clean build directory, so
+        # there are no stale coverage profiles to retain.
+        cargoLlvmCovExtraArgs = "--no-clean ${cargoLlvmCovExtraArgs}";
+        # Crane restores cargoArtifacts before cargo-llvm-cov runs. Point both
+        # tools at the same directory so the instrumented archive is restored
+        # where cargo-llvm-cov expects it.
+        CARGO_LLVM_COV_TARGET_DIR = "target/llvm-cov-target";
+        CARGO_TARGET_DIR = "target/llvm-cov-target";
         LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.pkgsBuildHost.openssl ];
         RUST_BACKTRACE = "full";
       }
@@ -239,6 +248,22 @@ let
     // {
       pname = pnameDeps;
       src = depsSrc;
+    }
+    // lib.optionalAttrs runCoverage {
+      # cargo-llvm-cov uses a separate instrumented target directory. Prepare
+      # dependencies under the same environment so the final coverage build
+      # can reuse them instead of recompiling the full dependency graph.
+      nativeBuildInputs = sharedArgs.nativeBuildInputs ++ [ craneLib.cargo-llvm-cov ];
+      buildPhaseCargoCommand = ''
+        eval "$(cargo llvm-cov show-env --sh)"
+        ${
+          if cargoLlvmCovCommand == "test" || cargoLlvmCovCommand == "nextest" then
+            "cargoWithProfile test ${sharedArgs.cargoExtraArgs} --no-run"
+          else
+            "cargoWithProfile build ${sharedArgs.cargoExtraArgs}"
+        }
+      '';
+      checkPhaseCargoCommand = "";
     }
     // lib.optionalAttrs (runTests || runNextest) {
       # A single no-run test build prepares normal and dev dependencies,

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -92,6 +92,30 @@ let
     lib.lists.take 3 (builtins.splitVersion crateInfo.version)
   );
 
+  # Cargo auto-discovers integration tests from their paths. Preserve those
+  # paths in Crane's dummy source so cargo-llvm-cov computes the same workspace
+  # crate set for dependency preparation and the final coverage build.
+  autoTestTargetPaths =
+    let
+      sourcePrefix = "${toString src}/";
+      relativePath = path: lib.removePrefix sourcePrefix (toString path);
+      isAutoTestTarget = path: builtins.match "(.*/)?tests/([^/]+\\.rs|[^/]+/main\\.rs)" path != null;
+    in
+    map relativePath (
+      lib.filter (path: isAutoTestTarget (relativePath path)) (lib.filesystem.listFilesRecursive src)
+    );
+
+  coverageNextestExtraDummyScript = lib.concatMapStringsSep "\n" (
+    path:
+    let
+      parent = builtins.dirOf path;
+    in
+    ''
+      mkdir -p "$out"/${lib.escapeShellArg parent}
+      touch "$out"/${lib.escapeShellArg path}
+    ''
+  ) autoTestTargetPaths;
+
   isDarwinForDarwin = buildPlatform.isDarwin && hostPlatform.isDarwin;
   isDarwinForNonDarwin = buildPlatform.isDarwin && !hostPlatform.isDarwin;
 
@@ -254,23 +278,29 @@ let
       # dependencies under the same environment so the final coverage build
       # can reuse them instead of recompiling the full dependency graph.
       nativeBuildInputs = sharedArgs.nativeBuildInputs ++ [ craneLib.cargo-llvm-cov ];
-      buildPhaseCargoCommand = ''
-        eval "$(cargo llvm-cov show-env --sh)"
-        ${
-          if cargoLlvmCovCommand == "nextest" then
-            "cargo nextest run --cargo-profile ${actualCargoProfile} ${sharedArgs.cargoExtraArgs} --no-run"
-          else if cargoLlvmCovCommand == "test" then
-            "cargoWithProfile test ${sharedArgs.cargoExtraArgs} --no-run"
-          else
-            "cargoWithProfile build ${sharedArgs.cargoExtraArgs}"
-        }
-      '';
+      buildPhaseCargoCommand =
+        if cargoLlvmCovCommand == "nextest" then
+          ''
+            cargo llvm-cov nextest --cargo-profile ${actualCargoProfile} ${sharedArgs.cargoExtraArgs} --no-report --no-tests=pass
+            cargo llvm-cov clean --workspace --profraw-only
+          ''
+        else
+          ''
+            eval "$(cargo llvm-cov show-env --sh)"
+            ${
+              if cargoLlvmCovCommand == "test" then
+                "cargoWithProfile test ${sharedArgs.cargoExtraArgs} --no-run"
+              else
+                "cargoWithProfile build ${sharedArgs.cargoExtraArgs}"
+            }
+          '';
       checkPhaseCargoCommand = "";
     }
     // lib.optionalAttrs (runCoverage && cargoLlvmCovCommand == "nextest") {
       # The final coverage derivation passes the Cargo profile explicitly to
       # nextest. Keep the dependency build's environment identical.
       CARGO_PROFILE = "";
+      extraDummyScript = coverageNextestExtraDummyScript;
     }
     // lib.optionalAttrs (runTests || runNextest) {
       # A single no-run test build prepares normal and dev dependencies,

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -211,7 +211,7 @@ let
 
   defaultArgs = {
     cargoArtifacts = craneLib.buildDepsOnly (
-      sharedArgs
+      builtins.removeAttrs sharedArgs [ "VERGEN_GIT_SHA" ]
       // {
         pname = pnameDeps;
         src = depsSrc;

--- a/lib/rust-package.nix
+++ b/lib/rust-package.nix
@@ -259,6 +259,14 @@ let
 
   args = if buildDocs then sharedArgs // docsArgs else sharedArgs // defaultArgs;
 
+  # cargo-llvm-cov's --profile option becomes the nextest runner profile when
+  # using its nextest subcommand. Pass the Cargo build profile through
+  # nextest's unambiguous --cargo-profile option instead.
+  coverageNextestArgs = lib.optionalAttrs (runCoverage && cargoLlvmCovCommand == "nextest") {
+    CARGO_PROFILE = "";
+    cargoExtraArgs = "--cargo-profile ${actualCargoProfile} ${args.cargoExtraArgs}";
+  };
+
   mkBench = import ./cargo-bench.nix {
     mkCargoDerivation = craneLib.mkCargoDerivation;
     noRun = buildBench;
@@ -282,6 +290,7 @@ let
 in
 builder (
   args
+  // coverageNextestArgs
   // {
     inherit src postInstall;
 


### PR DESCRIPTION
- Stabilizes Rust dependency derivations by excluding `VERGEN_GIT_SHA` and `BUILD_VERSION` from dependency-only builds, while retaining them in final artifacts.
- Keeps dependency cache invalidation tied to actual Cargo inputs, such as `Cargo.toml `and `Cargo.lock`.
- Adds optional final-build `BUILD_VERSION` support.
- Avoids redundant dependency compilation by preparing test artifacts with `cargo test --no-run --lib`.
- Prevents final test, Nextest, Clippy, and library derivations from recompressing reusable Cargo artifacts.
- Adds first-class Nextest support with configurable arguments and Cargo profiles.
- Fixes `cargo-llvm-cov nextest` profile handling by distinguishing Cargo build profiles from Nextest runner profiles.
- Updates examples and documentation for the new caching, testing, Nextest, and coverage options.